### PR TITLE
HDA-7972 [공통] jira_release 정규식 수정

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ const core = require('@actions/core');
 const rp = require('request-promise');
 
 let domain, project, version, token
+const versionRegExp = new RegExp(".*\\d{1,5}(\\.\\d{1,5}\\.)\\d{1,5}", "g");
+
 (async () => {
     try {
 
@@ -44,8 +46,7 @@ let domain, project, version, token
 })();
 
 function getVersionName(version) {
-    const regexp = new RegExp(".*(\\d{1,2}\\.\\d{1,2}\\.\\d{1,3})", "g");
-    const match = regexp.exec(version);
+    const match = versionRegExp.exec(version);
     if (match == null || match.length < 1) {
         return null
     }
@@ -94,8 +95,7 @@ async function releaseVersion(versionId) {
 }
 
 function isHotfixVersionName(versionName) {
-    const regexp = new RegExp(".*\\d{1,2}\\.\\d{1,2}\\.(\\d{1,3})", "g");
-    const patchVersion = regexp.exec(versionName)[1] * 1;
+    const patchVersion = versionRegExp.exec(versionName)[1] * 1;
     return patchVersion !== 0
 }
 
@@ -126,8 +126,7 @@ async function createNextVersion(versions) {
 function getNextVersion(versions) {
     const lastVersion = versions[versions.length - 1].name
     // Find minor version 1.[0].0
-    const regexp = new RegExp(".*\\d{1,5}(\\.\\d{1,5}\\.)\\d{1,5}", "g");
-    const lastMinorVersion = regexp.exec(lastVersion)[1];
+    const lastMinorVersion = versionRegExp.exec(lastVersion)[1];
     // Version change 1.0.0 -> 1.1.0
     const nextMinorVersionCode = lastMinorVersion.replace('.', '') * 1 + 1
     return lastVersion.replace(lastMinorVersion, `.${nextMinorVersionCode}.`)


### PR DESCRIPTION
# 개요 
1.4 버전에서 버전체크할 때 5자리씩 처리하도록 변경했습니다.
그런데 정규표현식이 총 3군데에 있었는데 이를 놓치고 `getNextVersion()`함수만 작업했습니다.
3개 모두 하나의 정규표현식을 사용하도록 변경합니다.