### PR TITLE
HDA-8184 [공통] jira-release 버전 못 찾는 오류 수정

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2,8 +2,6 @@ const core = require('@actions/core');
 const rp = require('request-promise');
 
 let domain, project, version, token
-const versionRegExp = new RegExp(".*\\d{1,5}(\\.\\d{1,5}\\.)\\d{1,5}", "g");
-
 (async () => {
     try {
 
@@ -46,7 +44,8 @@ const versionRegExp = new RegExp(".*\\d{1,5}(\\.\\d{1,5}\\.)\\d{1,5}", "g");
 })();
 
 function getVersionName(version) {
-    const match = versionRegExp.exec(version);
+    const regexp = new RegExp(".*(\\d{1,5}\\.\\d{1,5}\\.\\d{1,5})", "g");
+    const match = regexp.exec(version);
     if (match == null || match.length < 1) {
         return null
     }
@@ -95,7 +94,8 @@ async function releaseVersion(versionId) {
 }
 
 function isHotfixVersionName(versionName) {
-    const patchVersion = versionRegExp.exec(versionName)[1] * 1;
+    const regexp = new RegExp(".*\\d{1,5}\\.\\d{1,5}\\.(\\d{1,5})", "g");
+    const patchVersion = regexp.exec(versionName)[1] * 1;
     return patchVersion !== 0
 }
 
@@ -126,7 +126,8 @@ async function createNextVersion(versions) {
 function getNextVersion(versions) {
     const lastVersion = versions[versions.length - 1].name
     // Find minor version 1.[0].0
-    const lastMinorVersion = versionRegExp.exec(lastVersion)[1];
+    const regexp = new RegExp(".*\\d{1,5}(\\.\\d{1,5}\\.)\\d{1,5}", "g");
+    const lastMinorVersion = regexp.exec(lastVersion)[1];
     // Version change 1.0.0 -> 1.1.0
     const nextMinorVersionCode = lastMinorVersion.replace('.', '') * 1 + 1
     return lastVersion.replace(lastMinorVersion, `.${nextMinorVersionCode}.`)


### PR DESCRIPTION
## 개요

현재 정규표현식을 사용하는 코드에 2가지 문제가 있습니다.

1. RegExp.exec()를 2번 호출해서 사용하면 1번째는 잘 되지만 2번째는 null이 나와버린다.
2. 그룹을 전체로 지정하는 경우, minor 버전을 지정하는 경우, patch 버전을 지정하는 경우가 나뉘어있었는데 하나로 합쳐버렸다.

이 문제들을 해결하기 위해 일단 이전의 1.4 버전의 `index.js`로 되돌리고 만 단위까지 인식하도록 `{1,5}` 로만 모두 변경합니다.

## 반영화면
임시로 빌드해서 ncc 실행 커밋 추가해서 테스트해봤습니다.

- [실행 결과](https://github.com/PRNDcompany/heydealer-call-android/actions/runs/4249682028/jobs/7390061790)
- [릴리즈된 jira 버전](https://prndcompany.atlassian.net/projects/HDA/versions/10800/tab/release-report-all-issues)

## 기타
ncc를 도입하면서 코드에 변경이 생기면 배포용 `dist/index.js`에도 변경이 생겨야 합니다.
모든 PR에서 계속 저 파일을 변경하는건 무리가 있어서 이 프로젝트에서도 브랜치를 git flow 전략을 활용하기 위해 develop 브랜치를 push 해두고 이 PR도 target을 develop으로 해두었습니다.

추후 릴리즈 할 때만 release/xxx 브랜치에서 `npm run build`를 한 후에는 다른 프로젝트들과 똑같이 릴리즈해주면 됩니다.
