### PR TITLE
HDA-9676 [공통] GitHub Action set-output 마이그레이션

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Extract version name
-      run: echo "##[set-output name=version;]$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+      run: echo "version=$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
       id: extract_version_name           
     - name: Jira Release
       id: release


### PR DESCRIPTION
## 개요
2023년 6월 1일에 이미 지원 종료할 예정이었는데 사용하는 사람이 너무 많아서 연기했습니다. ([공식발표](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))
지원 종료 일자가 지났으므로 언제 종료할지 모르니 미리 변경해둡니다.

-----

A workflow using save-state or set-output like the following
```yaml
- name: Save state
run: echo "::save-state name={name}::{value}"

- name: Set output
run: echo "::set-output name={name}::{value}"
```

should be updated to write to the new GITHUB_STATE and GITHUB_OUTPUT environment files:

```yaml
- name: Save state
run: echo "{name}={value}" >> $GITHUB_STATE

- name: Set output
run: echo "{name}={value}" >> $GITHUB_OUTPUT
```