### PR TITLE
HDA-13756 [공통] workflow - Jira release 버전 목록 정렬 기능 추가

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -70,6 +70,20 @@ async function getVersions(appName) {
         const targetName = value.name.replace(versionName, '').trim()
         return targetName === appName
     })
+        // sort by version number
+        // [1.10.0, 1.11.0, 1.9.0] -> [1.9.0, 1.10.0, 1.11.0]
+        .sort((a, b) => {
+            const aVersion = a.name.match(/\d+(\.\d+)+/)[0].split('.').map(Number);
+            const bVersion = b.name.match(/\d+(\.\d+)+/)[0].split('.').map(Number);
+
+            for (let i = 0; i < Math.max(aVersion.length, bVersion.length); i++) {
+                const aPart = aVersion[i] || 0;
+                const bPart = bVersion[i] || 0;
+                if (aPart > bPart) return 1;
+                if (aPart < bPart) return -1;
+            }
+            return 0;
+        });
 }
 
 async function releaseVersion(versionId) {


### PR DESCRIPTION
## 현상
- 7.9.0 jira release처리할때 오류발생함
: https://github.com/PRNDcompany/heydealer-android/actions/runs/9806251563/job/27077570498 
- 7.11.0 안만들어짐

## 원인
- Jira API로 versions의 목록을 받아오고 있는데 
- 우리가 기대한 결과는 [7.9.0, 7.10.0] 이었으나
- 실제는 abc순서대로 정렬되어 내려오기 때문에 [7.10.0, 7.9.0]으로 내려옴

## 해결
- versions의 목록을 우리가 기대한 숫자순으로 정렬되도록 하는 로직을 추가해서 의도된 동작대로 이루어지도록 수정